### PR TITLE
Make '|' bind weaker than concatenation (adjust alternation precedence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,17 @@ Examples:
 
 ## 2. Alternation
 
-Alternation matches any one subexpression separated by `|`.
+In regexcv, `|` applies to a **single term**, and then concatenation joins the surrounding terms.
+
+That means `ab|cd` is parsed as `a(b|c)d`, so it matches `abd` or `acd`.
+
+If you want classic whole-branch alternation, use parentheses explicitly, for example `(ab)|(cd)`.
 
 Examples:
 
 - The regex `a|b` matches: `"a", "b"`
-- The regex `a|` matches: `"a", ""`
-- The regex `|` matches: `""`
+- The regex `ab|cd` matches: `"abd", "acd"`
+- The regex `(ab)|(cd)` matches: `"ab", "cd"`
 
 ## 3. Escape and Special Characters
 

--- a/src/main/java/com/nano/regexcv/syntax/InnerRegexParser.java
+++ b/src/main/java/com/nano/regexcv/syntax/InnerRegexParser.java
@@ -115,17 +115,14 @@ public class InnerRegexParser {
    * <p>A regular expression is represented as the concatenation of multiple subexpressions.
    */
   protected RegularExpression parseRegex() {
-    return parseAlternation();
+    return parseConcatenation();
   }
 
   /** Parses one or more concatenation expressions. */
   private RegularExpression parseConcatenation() {
     LinkedList<RegularExpression> concatenation = new LinkedList<>();
     while (!isEnd() && ch != ')') {
-      if (ch == '|') {
-        break;
-      }
-      concatenation.add(parseTerm());
+      concatenation.add(parseAlternation());
     }
     if (concatenation.isEmpty()) {
       return new REmpty();
@@ -140,19 +137,26 @@ public class InnerRegexParser {
    * Parses one or more alternation expressions.
    *
    * <pre>{@code
-   * Syntax: ( Term ( '|' [ Term ] )* ) | ( '|' [ Term ] )+
+   * Syntax: [ Term ] ( '|' [ Term ] )*
    * }</pre>
    */
   private RegularExpression parseAlternation() {
     var list = new ArrayList<RegularExpression>();
-    list.add(parseConcatenation());
+    list.add(parseOptionalTerm());
     while (got('|')) {
-      list.add(parseConcatenation());
+      list.add(parseOptionalTerm());
     }
     if (list.size() == 1) {
       return list.get(0);
     }
     return new RAlternation(list);
+  }
+
+  private RegularExpression parseOptionalTerm() {
+    if (this.ch == ')' || this.ch == '|' || isEnd()) {
+      return new REmpty();
+    }
+    return parseTerm();
   }
 
   /**

--- a/src/test/java/com/nano/regexcv/syntax/ParserTest.java
+++ b/src/test/java/com/nano/regexcv/syntax/ParserTest.java
@@ -48,16 +48,13 @@ public class ParserTest {
     RegexParser parser = new RegexParser();
 
     RegularExpression regex = parser.accept("ab|cd");
-    assertTrue(regex instanceof RAlternation);
+    assertTrue(regex instanceof RContatenation);
 
-    RAlternation alternation = (RAlternation) regex;
+    RContatenation concatenation = (RContatenation) regex;
+    assertEquals(3, concatenation.getRegexList().size());
+    assertTrue(concatenation.getRegexList().get(1) instanceof RAlternation);
+
+    RAlternation alternation = (RAlternation) concatenation.getRegexList().get(1);
     assertEquals(2, alternation.getRegexList().size());
-    assertTrue(alternation.getRegexList().get(0) instanceof RContatenation);
-    assertTrue(alternation.getRegexList().get(1) instanceof RContatenation);
-
-    RContatenation left = (RContatenation) alternation.getRegexList().get(0);
-    RContatenation right = (RContatenation) alternation.getRegexList().get(1);
-    assertEquals(2, left.getRegexList().size());
-    assertEquals(2, right.getRegexList().size());
   }
 }


### PR DESCRIPTION
### Motivation
- Change the parser so alternation (`|`) has lower precedence than concatenation, i.e. `ab|cd` should parse as `a(b|c)d` rather than as two separate alternatives `ab` or `cd`.

### Description
- In `InnerRegexParser.java` `parseRegex()` now starts from `parseConcatenation()` and `parseConcatenation()` builds its pieces by calling `parseAlternation()` so concatenation binds tighter than `|`.
- `parseAlternation()` was rewritten to use a new `parseOptionalTerm()` that returns `REmpty` for empty branches, preserving forms like `a|`, `|a`, and `||` while making `|` apply only to a single term.
- Updated `ParserTest` to expect `ab|cd` to produce an `RContatenation` with an inner `RAlternation` (reflecting `a(b|c)d`).
- Updated `README.md` alternation section to document the new semantics and to recommend parentheses `(ab)|(cd)` for classic branch alternation.

### Testing
- Compiled core parser and supporting classes with `javac -d /tmp/regexcv-out src/main/java/com/nano/regexcv/Pass.java $(find src/main/java/com/nano/regexcv/syntax -name '*.java') $(find src/main/java/com/nano/regexcv/syntax/tree -name '*.java') $(find src/main/java/com/nano/regexcv/util -name '*.java')`, which succeeded.
- Executed the smoke test by compiling and running `ParserSmokeTest` (`javac -cp /tmp/regexcv-out -d /tmp/regexcv-out /tmp/ParserSmokeTest.java && java -cp /tmp/regexcv-out ParserSmokeTest`), which printed `ok` and passed.
- `./gradlew test` and `gradle test` could not run in this environment due to Gradle wrapper download/proxy issues and a missing plugin resolution error, so the full test-suite run failed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f6c0aa53c8333a6bca7b094c0980a)